### PR TITLE
added a main to bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -4,6 +4,7 @@
   "authors": [
     "Matt Lo <mattlo.developer@gmail.com>"
   ],
+  "main": "angular-terminal.js",
   "description": "A port of jQuery.terminal into AngularJS",
   "keywords": [
     "angular",


### PR DESCRIPTION
javascript build systems fails to inject this angular module if main attribute is not there.